### PR TITLE
Make base urls configurable to interface with openAI compliant servers

### DIFF
--- a/README.org
+++ b/README.org
@@ -21,8 +21,9 @@ emacs toolings. Here is the basic things you will need for set-up:
     (require 'gptai)
     ;; set configurations
     (setq gptai-model "<MODEL-HERE>") 
-    (setq gptai-username "<USERNAME-HERE>")
     (setq gptai-api-key "<API-KEY-HERE>")
+    ;; if required, specify an alternative base url
+    (setq gptai-base-url "https://api.foo.bar.baz/v1/completions")
     ;; set keybindings optionally
     (global-set-key (kbd "C-c o") 'gptai-send-query)
   #+end_src
@@ -33,8 +34,8 @@ To fill out the details of the configuration section
   ~gptai-list-models~ , it will also display this list in the *gptai*
   buffer. Use this to choose a model and set ~gptai-model~ (text-davinci-003 is
   a good default model).
-- Define your OpenAI username.
 - Define your API key (your own key can be obtained from [[https://platform.openai.com/account/api-keys][OpenAI API Keys]])
+- Define an alternative base URL for an openao API endpoint 
 
 After that optionally fill out the init section with some keybindings.
 

--- a/gptai.el
+++ b/gptai.el
@@ -52,7 +52,6 @@
 ;;   (require 'gptai)
 ;;   ;; set standard configurations
 ;;   (setq gptai-model "<MODEL-HERE>")
-;;   (setq gptai-username "<USERNAME-HERE>")
 ;;   (setq gptai-api-key "<API-KEY-HERE>")
 ;;   ;; set keybindings optionally
 ;;   (global-set-key (kbd "C-c o") 'gptai-send-query)

--- a/gptai.el
+++ b/gptai.el
@@ -123,8 +123,8 @@ Argument GPTAI-PROMPT is the prompt to send to the API."
          (url-request-data
           (json-encode `(("model" . ,gptai-model)
                          ("prompt" . ,gptai-prompt)
-                         ("temperature" . gptai-temperature)
-                         ("max_tokens" . gptai-max-tokens))))
+                         ("temperature" . ,gptai-temperature)
+                         ("max_tokens" . ,gptai-max-tokens))))
          (buffer (url-retrieve-synchronously gptai-base-url nil 'silent))
          response)
 

--- a/gptai.el
+++ b/gptai.el
@@ -72,8 +72,14 @@
 (require 'json)
 
 ;; default values for local variables
-(defvar gptai-base-url "https://api.openai.com/v1/completions")
-(defvar gptai-chat-url "https://api.openai.com/v1/chat/completions")
+(defcustom gptai-base-url "https://api.openai.com/v1/completions"
+  "API base url for OpenAI completions endpoint."
+  :type 'string
+  :group 'gptai)
+(defcustom gptai-chat-url "https://api.openai.com/v1/chat/completions"
+  "API url for OpenAI chat endpoint."
+  :type 'string
+  :group 'gptai)
 (defcustom gptai-model ""
   "API Model for OpenAI."
   :type 'string

--- a/gptai.el
+++ b/gptai.el
@@ -76,6 +76,10 @@
   "API base url for OpenAI completions endpoint."
   :type 'string
   :group 'gptai)
+(defcustom gptai-models-url "https://api.openai.com/v1/models"
+  "API url for listing OpenAI models."
+  :type 'string
+  :group 'gptai)
 (defcustom gptai-chat-url "https://api.openai.com/v1/chat/completions"
   "API url for OpenAI chat endpoint."
   :type 'string
@@ -354,8 +358,8 @@ Argument FILEPATH filepath to download to."
   (interactive)
   (with-current-buffer (get-buffer-create "*gptai-models*")
     (erase-buffer)
-    (async-shell-command (format "curl https://api.openai.com/v1/models \
-    -H 'Authorization: Bearer %s'" gptai-api-key) "*gptai-models*" "*Messages*")
+    (async-shell-command (format "curl %s \
+    -H 'Authorization: Bearer %s'" gptai-models-url gptai-api-key) "*gptai-models*" "*Messages*")
     (goto-char (point-min))
     (re-search-forward "^.*object.*$")
     (delete-region (point-min) (point))

--- a/gptai.el
+++ b/gptai.el
@@ -84,6 +84,10 @@
   "API url for OpenAI chat endpoint."
   :type 'string
   :group 'gptai)
+(defcustom gptai-images-url "https://api.openai.com/v1/images/generations"
+  "API base url for generating OpenAI images."
+  :type 'string
+  :group 'gptai)
 (defcustom gptai-model ""
   "API Model for OpenAI."
   :type 'string
@@ -310,7 +314,7 @@ Argument FILEPATH filepath to download to."
          (read-directory-name "Enter output directory: " "~/Pictures")))
   (when (null gptai-api-key)
     (error "OpenAI API key is not set"))
-  (let* ((url "https://api.openai.com/v1/images/generations")
+  (let* ((url (custom-value 'gptai-images-url))
          (url-request-method "POST")
          (url-request-extra-headers
           `(("Content-Type" . "application/json")


### PR DESCRIPTION
This fix may broaded the user base of this package by allowing non-openai hosted servers to be accessed.